### PR TITLE
record exit code of internal process submitted to qsub

### DIFF
--- a/onmt.tape
+++ b/onmt.tape
@@ -535,9 +535,13 @@ submitter sge :: action_flags
     echo "cd $PWD" >> $wrapper
 
     echo "$COMMANDS" >> $wrapper
+    echo "echo \$? > exitcode" >> $wrapper
 
     # Use SGE's -sync option to prevent qsub from immediately returning
     qsub -sync y $wrapper
+    
+    EXITCODE=$(cat $PWD/exitcode)
+    [ $EXITCODE = "0" ]
   }
 }
 


### PR DESCRIPTION
This PR modifies the SGE submitter so that it
 - saves the exit code of the internal process (the one submitted to qsub) to a file named `exitcode`
 - after termination of the internal process, returns the saved exit code as the exit code of this job